### PR TITLE
Ensured secrets arent logged by

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt::Debug};
 
 use josekit::{
     jwe::{JweDecrypter, JweEncrypter, ECDH_ES, RSA_OAEP},
@@ -11,9 +11,15 @@ use crate::error::Error;
 //
 // Configuration management
 //
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize)]
 pub struct InnerKeyConfig {
     key: String,
+}
+
+impl Debug for InnerKeyConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InnerKeyConfig").finish()
+    }
 }
 
 /// Parsable configuration describing an encryption key.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,4 +205,34 @@ mod tests {
             decrypt_and_verify_auth_result(&jwe, verifier.as_ref(), decrypter.as_ref()).unwrap();
         assert_eq!(in_result, out_result);
     }
+
+    #[test]
+    fn test_log_hiding_rsa() {
+        let dec_config: EncryptionKeyConfig = serde_yaml::from_str(RSA_PRIVKEY).unwrap();
+        assert_eq!(format!("{:?}", dec_config), "RSA(InnerKeyConfig)");
+
+        let decrypter = Box::<dyn JweDecrypter>::try_from(dec_config).unwrap();
+        assert_eq!(format!("{:?}", decrypter), "RsaesJweDecrypter { algorithm: RsaOaep, private_key: PKey { algorithm: \"RSA\" }, key_id: None }");
+
+        let sig_config: SignKeyConfig = serde_yaml::from_str(RSA_PRIVKEY).unwrap();
+        assert_eq!(format!("{:?}", sig_config), "RSA(InnerKeyConfig)");
+
+        let signer = Box::<dyn JwsSigner>::try_from(sig_config).unwrap();
+        assert_eq!(format!("{:?}", signer), "RsassaJwsSigner { algorithm: Rs256, private_key: PKey { algorithm: \"RSA\" }, key_id: None }")
+    }
+
+    #[test]
+    fn test_log_hiding_ec() {
+        let dec_config: EncryptionKeyConfig = serde_yaml::from_str(EC_PRIVKEY).unwrap();
+        assert_eq!(format!("{:?}", dec_config), "EC(InnerKeyConfig)");
+
+        let decrypter = Box::<dyn JweDecrypter>::try_from(dec_config).unwrap();
+        assert_eq!(format!("{:?}", decrypter), "EcdhEsJweDecrypter { algorithm: EcdhEs, private_key: PKey { algorithm: \"EC\" }, key_type: Ec(P256), key_id: None }");
+
+        let sig_config: SignKeyConfig = serde_yaml::from_str(EC_PRIVKEY).unwrap();
+        assert_eq!(format!("{:?}", sig_config), "EC(InnerKeyConfig)");
+
+        let signer = Box::<dyn JwsSigner>::try_from(sig_config).unwrap();
+        assert_eq!(format!("{:?}", signer), "EcdsaJwsSigner { algorithm: Es256, private_key: PKey { algorithm: \"EC\" }, key_id: None }")
+    }
 }


### PR DESCRIPTION
 - Manually deriving Debug for InnerKeyConfig and ensuring it doesn't
write the actual key material
 - Checking for all relevant types in this library that their debug
behaviour is ok.